### PR TITLE
Removes success payload check because of upstream Harbor issues

### DIFF
--- a/services/webhooks2tasks/src/handlers/problems/harborScanningCompleted.ts
+++ b/services/webhooks2tasks/src/handlers/problems/harborScanningCompleted.ts
@@ -37,20 +37,6 @@ const PROBLEMS_HARBOR_FILTER_FLAG = process.env.PROBLEMS_HARBOR_FILTER_FLAG || n
       harborScanId,
     } = await validateAndTransformIncomingWebhookdata(harborScanPatternMatchers.allProblemHarborScanMatchers, body);
 
-    if(scanOverview.scan_status !== HARBOR_WEBHOOK_SUCCESSFUL_SCAN) {
-      sendToLagoonLogs(
-        'error',
-        '',
-        uuid,
-        `${webhooktype}:${event}:unhandled`,
-        { data: body },
-        `Received a scan report of status "${scanOverview.scan_status}" - ignoring`
-      );
-
-      return;
-    }
-
-
     let { id: lagoonProjectId, problemsUi } = await getProjectByName(lagoonProjectName);
 
     //Here, before we get any further, we only let through projects that have the problemsUI enabled


### PR DESCRIPTION
Here we remove the check discussed in #2670 in `lagoon` - namely the part of the Harbor webhook payload that describes the current state of the scan (we check for a "success" in the "scan_overview" section (which is returning inaccurate information).

